### PR TITLE
Globals wasm

### DIFF
--- a/lib/Runtime/ByteCode/OpCodesAsmJs.h
+++ b/lib/Runtime/ByteCode/OpCodesAsmJs.h
@@ -231,6 +231,12 @@ MACRO_EXTEND_WMS( Nearest_Db                 , Double2         , None           
 MACRO_EXTEND_WMS( Nearest_Flt                , Float2          , None            )
 MACRO_EXTEND_WMS( PopCnt_Int                 , Int2            , None            ) 
 MACRO_EXTEND_WMS( CurrentMemory_Int          , AsmReg1         , None            )
+MACRO_EXTEND_WMS( GetGlobal_Int              , Int2            , None            ) 
+MACRO_EXTEND_WMS( GetGlobal_Flt              , Float1Int1      , None            )
+MACRO_EXTEND_WMS( GetGlobal_Db               , Double1Int1     , None            )
+MACRO_EXTEND_WMS( SetGlobal_Int              , Int2            , None            ) 
+MACRO_EXTEND_WMS( SetGlobal_Flt              , Int1Float1      , None            )
+MACRO_EXTEND_WMS( SetGlobal_Db               , Int1Double1     , None            )
 
 #define MACRO_SIMD(opcode, asmjsLayout, opCodeAttrAsmJs, OpCodeAttr, ...) MACRO(opcode, asmjsLayout, opCodeAttrAsmJs)
 #define MACRO_SIMD_WMS(opcode, asmjsLayout, opCodeAttrAsmJs, OpCodeAttr, ...) MACRO_WMS(opcode, asmjsLayout, opCodeAttrAsmJs)

--- a/lib/Runtime/Language/InterpreterHandlerAsmJs.inl
+++ b/lib/Runtime/Language/InterpreterHandlerAsmJs.inl
@@ -180,6 +180,10 @@ EXDEF2_WMS( F1toF1Mem        , Nearest_Flt      , Wasm::WasmMath::Nearest<float>
 EXDEF2_WMS( D1toD1Mem        , Trunc_Db         , Wasm::WasmMath::Trunc<double>                      )
 EXDEF2_WMS( D1toD1Mem        , Nearest_Db       , Wasm::WasmMath::Nearest<double>                    )
 EXDEF2_WMS( I1toI1Mem        , PopCnt_Int       , ::Math::PopCnt32                                   )
+EXDEF2_WMS( I1toI1Mem        , GetGlobal_Int,     OP_GetGlobalInt                                    )
+EXDEF3_WMS( CUSTOM_ASMJS     , SetGlobal_Int,     OP_SetGlobalInt, Int2                              )
+
+
 EXDEF2_WMS( VtoI1Mem         , CurrentMemory_Int, OP_GetMemorySize                                   )
 
   DEF2_WMS( IP_TARG_ASM      , AsmJsLoopBodyStart, OP_ProfiledLoopBodyStart                      )

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -2962,7 +2962,7 @@ namespace Js
         
         m_localSlots[AsmJsFunctionMemory::ModuleEnvRegister] = frame->GetItem(0);
         m_localSlots[AsmJsFunctionMemory::ArrayBufferRegister] = (Var*)frame->GetItem(0) + AsmJsModuleMemory::MemoryTableBeginOffset;
-        m_localSlots[AsmJsFunctionMemory::ArraySizeRegister] = frame->GetLength() > 1 ? frame->GetItem(1) : 0; // do not cache ArraySize in the interpreter
+        m_localSlots[AsmJsFunctionMemory::ArraySizeRegister] = frame->GetLength() > 1 ? frame->GetItem(1) : 0; // GetItem(1) is offset into globals array
         m_localSlots[AsmJsFunctionMemory::ScriptContextBufferRegister] = functionBody->GetScriptContext();
 
         if (PHASE_TRACE1(AsmjsInterpreterStackPhase))
@@ -7693,7 +7693,7 @@ int InterpreterStackFrame::OP_GetGlobalInt(int index)
     {
 #ifdef ASMJS_PLAT
         WasmGlobal* globals = (WasmGlobal*)GetNonVarReg(AsmJsFunctionMemory::ArraySizeRegister);
-        Assert(!globals[index].IsReference()); //no references at this point should have been resolved at link-time.
+        Assert(!globals[index].IsReference()); //no references at this point; everything should have been resolved at link-time.
         return globals[index].cnst.i32;
 #else
         return 0;
@@ -7719,7 +7719,7 @@ void InterpreterStackFrame::OP_SetGlobalInt(const unaligned T* playout)
     
     
 #else
-    return 0;
+    return;
 #endif
 }
 

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -179,6 +179,12 @@ namespace Js
 
         void ValidateRegValue(Var value, bool allowStackVar = false, bool allowStackVarOnDisabledStackNestedFunc = true) const;
         int OP_GetMemorySize();
+
+        int OP_GetGlobalInt(int);
+        //void OP_SetGlobalInt(int, int);
+        template <class T> void OP_SetGlobalInt(const unaligned T* playout);
+        
+
         void ValidateSetRegValue(Var value, bool allowStackVar = false, bool allowStackVarOnDisabledStackNestedFunc = true) const;
         template <typename RegSlotType> Var GetReg(RegSlotType localRegisterID) const;
         template <typename RegSlotType> void SetReg(RegSlotType localRegisterID, Var bValue);

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -181,7 +181,6 @@ namespace Js
         int OP_GetMemorySize();
 
         int OP_GetGlobalInt(int);
-        //void OP_SetGlobalInt(int, int);
         template <class T> void OP_SetGlobalInt(const unaligned T* playout);
         
 

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -10,7 +10,7 @@ namespace Js
 
     WasmGlobal* WasmGlobal::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "var must be an WasmGlobal");
+        AssertMsg(Is(aValue), "var must be a WasmGlobal");
         return static_cast<WasmGlobal *>(RecyclableObject::FromVar(aValue));
     }
 

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -6,6 +6,14 @@
 
 namespace Js
 {
+
+
+    WasmGlobal* WasmGlobal::FromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "var must be an WasmGlobal");
+        return static_cast<WasmGlobal *>(RecyclableObject::FromVar(aValue));
+    }
+
     ArrayBuffer* ArrayBuffer::NewFromDetachedState(DetachedStateBase* state, JavascriptLibrary *library)
     {
         ArrayBufferDetachedStateBase* arrayBufferState = (ArrayBufferDetachedStateBase *)state;

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -6,8 +6,63 @@
 //----------------------------------------------------------------------------
 
 #pragma once
+
+#include "../WasmReader/WasmParseTree.h"
+
 namespace Js
 {
+
+
+
+
+
+    class WasmGlobal : public DynamicObject
+    {
+    private:
+
+        DEFINE_VTABLE_CTOR(WasmGlobal, DynamicObject);
+        DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(WasmGlobal);
+    //protected:
+    //    WasmGlobal(DynamicType * type);
+
+    public:
+        uint type;
+        bool mut;
+        bool isRef;
+
+        /*
+        struct WasmConst
+        {
+            union
+            {
+                float f32;
+                double f64;
+                int32 i32;
+                int64 i64;
+            };
+        };
+        */
+            union
+            {
+                Wasm::WasmConstLitNode cnst;
+                Var var;
+            };
+
+ 
+        WasmGlobal(Var val, DynamicType * type) : DynamicObject(type), var(val) {};
+        WasmGlobal(Wasm::WasmConstLitNode c, DynamicType * type) : DynamicObject(type), cnst(c) {};
+        static bool Is(Var aValue) { return JavascriptOperators::GetTypeId(aValue) == TypeIds_WasmGlobal; }
+        static WasmGlobal* FromVar(Var aValue);
+
+
+        //Var GetValue() const {return value; };
+        //void SetValue(Var val) { value = val; };
+
+        //@TODO : implement
+        //virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
+        //virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
+    };
+
     class ArrayBufferParent;
     class ArrayBuffer : public DynamicObject
     {

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -24,9 +24,9 @@ namespace Js
 
         DEFINE_VTABLE_CTOR(WasmGlobal, DynamicObject);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(WasmGlobal);
-        
+
     public:
-        
+
         bool IsMutable() { return m_mutable;  };
         void SetMutability(bool mut) { m_mutable = mut; };
 
@@ -42,20 +42,20 @@ namespace Js
             Var var;
         };
 
-        WasmGlobal(Var val, DynamicType * type) : 
-            DynamicObject(type), 
-            var(val), 
-            m_type(0), 
-            m_mutable(false), 
-            m_reference(true) 
+        WasmGlobal(Var val, DynamicType * type) :
+            DynamicObject(type),
+            var(val),
+            m_type(0),
+            m_mutable(false),
+            m_reference(true)
         {};
 
-        WasmGlobal(Wasm::WasmConstLitNode c, DynamicType * type) : 
-            DynamicObject(type), 
-            cnst(c), 
-            m_type(0), 
-            m_mutable(false), 
-            m_reference(false) 
+        WasmGlobal(Wasm::WasmConstLitNode c, DynamicType * type) :
+            DynamicObject(type),
+            cnst(c),
+            m_type(0),
+            m_mutable(false),
+            m_reference(false)
         {};
 
         static bool Is(Var aValue) { return JavascriptOperators::GetTypeId(aValue) == TypeIds_WasmGlobal; }

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -18,49 +18,61 @@ namespace Js
 
     class WasmGlobal : public DynamicObject
     {
-    private:
+        bool m_mutable;
+        bool m_reference;
+        uint m_type;
 
         DEFINE_VTABLE_CTOR(WasmGlobal, DynamicObject);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(WasmGlobal);
-    //protected:
-    //    WasmGlobal(DynamicType * type);
-
+        
     public:
-        uint type;
-        bool mut;
-        bool isRef;
+        
+        bool IsMutable() { return m_mutable;  };
+        void SetMutability(bool mut) { m_mutable = mut; };
 
-        /*
-        struct WasmConst
+        bool IsReference() { return m_reference; };
+        void SetIsReference(bool ref) { m_reference = ref; };
+
+        uint GetType() { return m_type; };
+        void SetType(uint ty) { m_type = ty; };
+
+        union
         {
-            union
-            {
-                float f32;
-                double f64;
-                int32 i32;
-                int64 i64;
-            };
+            Wasm::WasmConstLitNode cnst;
+            Var var;
         };
-        */
-            union
-            {
-                Wasm::WasmConstLitNode cnst;
-                Var var;
-            };
 
- 
-        WasmGlobal(Var val, DynamicType * type) : DynamicObject(type), var(val) {};
-        WasmGlobal(Wasm::WasmConstLitNode c, DynamicType * type) : DynamicObject(type), cnst(c) {};
+        WasmGlobal(Var val, DynamicType * type) : 
+            DynamicObject(type), 
+            var(val), 
+            m_type(0), 
+            m_mutable(false), 
+            m_reference(true) 
+        {};
+
+        WasmGlobal(Wasm::WasmConstLitNode c, DynamicType * type) : 
+            DynamicObject(type), 
+            cnst(c), 
+            m_type(0), 
+            m_mutable(false), 
+            m_reference(false) 
+        {};
+
         static bool Is(Var aValue) { return JavascriptOperators::GetTypeId(aValue) == TypeIds_WasmGlobal; }
         static WasmGlobal* FromVar(Var aValue);
 
+        BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override
+        {
+            stringBuilder->AppendCppLiteral(_u("Object, (WasmGlobal)"));
+            return TRUE;
+        }
 
-        //Var GetValue() const {return value; };
-        //void SetValue(Var val) { value = val; };
+        BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)
+        {
+            stringBuilder->AppendCppLiteral(_u("[object WasmGlobal]"));
+            return TRUE;
+        }
 
-        //@TODO : implement
-        //virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
-        //virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
     };
 
     class ArrayBufferParent;

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1337,11 +1337,6 @@ namespace Js
             DeferredTypeHandler<InitializeRegexConstructor>::GetDefaultInstance());
         regexConstructor = RecyclerNewEnumClass(recycler, EnumFunctionClass, JavascriptRegExpConstructor, regexConstructorType);
         AddFunction(globalObject, PropertyIds::RegExp, regexConstructor);
-
-        wasmGlobalConstructor = nullptr;//CreateBuiltinConstructor(&ArrayBuffer::EntryInfo::NewInstance,
-            //DeferredTypeHandler<InitializeWasmGlobalConstructor>::GetDefaultInstance());
-        //AddFunction(globalObject, PropertyIds::ArrayBuffer, arrayBufferConstructor);
-
         arrayBufferConstructor = CreateBuiltinConstructor(&ArrayBuffer::EntryInfo::NewInstance,
             DeferredTypeHandler<InitializeArrayBufferConstructor>::GetDefaultInstance());
         AddFunction(globalObject, PropertyIds::ArrayBuffer, arrayBufferConstructor);
@@ -1690,40 +1685,13 @@ namespace Js
         arrayPrototype->SetHasNoEnumerableProperties(true);
     }
 
-    void  JavascriptLibrary::InitializeWasmGlobalConstructor(DynamicObject* wasmGlobalConstructor, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode)
-    {
-        typeHandler->Convert(wasmGlobalConstructor, mode, 4);
-
-        ScriptContext* scriptContext = wasmGlobalConstructor->GetScriptContext();
-        JavascriptLibrary* library = wasmGlobalConstructor->GetLibrary();
-
-        library->AddMember(wasmGlobalConstructor, PropertyIds::prototype, scriptContext->GetLibrary()->wasmGlobalPrototype, PropertyNone);
-
-
-        //@TODO i doubt we are going to need these 
-
-        /*
-        if (scriptContext->GetConfig()->IsES6SpeciesEnabled())
-        {
-        library->AddAccessorsToLibraryObject(wasmGlobalConstructor, PropertyIds::_symbolSpecies, &ArrayBuffer::EntryInfo::GetterSymbolSpecies, nullptr);
-        }
-
-        if (scriptContext->GetConfig()->IsES6FunctionNameEnabled())
-        {
-        library->AddMember(wasmGlobalConstructor, PropertyIds::name, scriptContext->GetPropertyString(PropertyIds::ArrayBuffer), PropertyConfigurable);
-        }
-        */
-
-        wasmGlobalConstructor->SetHasNoEnumerableProperties(true);
-    }
-
     void  JavascriptLibrary::InitializeWasmGlobalPrototype(DynamicObject* wasmGlobalPrototype, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode)
     {
         typeHandler->Convert(wasmGlobalPrototype, mode, 2);
 
         ScriptContext* scriptContext = wasmGlobalPrototype->GetScriptContext();
         JavascriptLibrary* library = wasmGlobalPrototype->GetLibrary();
-        library->AddMember(wasmGlobalPrototype, PropertyIds::constructor, library->undefinedValue /*no c-tor sry*/);
+        library->AddMember(wasmGlobalPrototype, PropertyIds::constructor, library->undefinedValue /*no c-tor*/);
 
         if (scriptContext->GetConfig()->IsES6ToStringTagEnabled())
         {

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -133,6 +133,13 @@ namespace Js
 
         constructorPrototypeObjectType->SetHasNoEnumerableProperties(true);
 
+        wasmGlobalPrototype = DynamicObject::New(recycler,
+            DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
+                DeferredTypeHandler<InitializeWasmGlobalPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
+
+        wasmGlobalType = DynamicType::New(scriptContext, TypeIds_WasmGlobal, wasmGlobalPrototype, nullptr,
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
+
         arrayBufferPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
                 DeferredTypeHandler<InitializeArrayBufferPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
@@ -439,6 +446,9 @@ namespace Js
             SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 #endif
         nativeFloatArrayType = DynamicType::New(scriptContext, TypeIds_NativeFloatArray, arrayPrototype, nullptr,
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
+
+        wasmGlobalType = DynamicType::New(scriptContext, TypeIds_WasmGlobal, wasmGlobalPrototype, nullptr,
             SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         arrayBufferType = DynamicType::New(scriptContext, TypeIds_ArrayBuffer, arrayBufferPrototype, nullptr,
@@ -1328,6 +1338,10 @@ namespace Js
         regexConstructor = RecyclerNewEnumClass(recycler, EnumFunctionClass, JavascriptRegExpConstructor, regexConstructorType);
         AddFunction(globalObject, PropertyIds::RegExp, regexConstructor);
 
+        wasmGlobalConstructor = nullptr;//CreateBuiltinConstructor(&ArrayBuffer::EntryInfo::NewInstance,
+            //DeferredTypeHandler<InitializeWasmGlobalConstructor>::GetDefaultInstance());
+        //AddFunction(globalObject, PropertyIds::ArrayBuffer, arrayBufferConstructor);
+
         arrayBufferConstructor = CreateBuiltinConstructor(&ArrayBuffer::EntryInfo::NewInstance,
             DeferredTypeHandler<InitializeArrayBufferConstructor>::GetDefaultInstance());
         AddFunction(globalObject, PropertyIds::ArrayBuffer, arrayBufferConstructor);
@@ -1674,6 +1688,49 @@ namespace Js
         DebugOnly(CheckRegisteredBuiltIns(builtinFuncs, scriptContext));
 
         arrayPrototype->SetHasNoEnumerableProperties(true);
+    }
+
+    void  JavascriptLibrary::InitializeWasmGlobalConstructor(DynamicObject* wasmGlobalConstructor, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode)
+    {
+        typeHandler->Convert(wasmGlobalConstructor, mode, 4);
+
+        ScriptContext* scriptContext = wasmGlobalConstructor->GetScriptContext();
+        JavascriptLibrary* library = wasmGlobalConstructor->GetLibrary();
+
+        library->AddMember(wasmGlobalConstructor, PropertyIds::prototype, scriptContext->GetLibrary()->wasmGlobalPrototype, PropertyNone);
+
+
+        //@TODO i doubt we are going to need these 
+
+        /*
+        if (scriptContext->GetConfig()->IsES6SpeciesEnabled())
+        {
+        library->AddAccessorsToLibraryObject(wasmGlobalConstructor, PropertyIds::_symbolSpecies, &ArrayBuffer::EntryInfo::GetterSymbolSpecies, nullptr);
+        }
+
+        if (scriptContext->GetConfig()->IsES6FunctionNameEnabled())
+        {
+        library->AddMember(wasmGlobalConstructor, PropertyIds::name, scriptContext->GetPropertyString(PropertyIds::ArrayBuffer), PropertyConfigurable);
+        }
+        */
+
+        wasmGlobalConstructor->SetHasNoEnumerableProperties(true);
+    }
+
+    void  JavascriptLibrary::InitializeWasmGlobalPrototype(DynamicObject* wasmGlobalPrototype, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode)
+    {
+        typeHandler->Convert(wasmGlobalPrototype, mode, 2);
+
+        ScriptContext* scriptContext = wasmGlobalPrototype->GetScriptContext();
+        JavascriptLibrary* library = wasmGlobalPrototype->GetLibrary();
+        library->AddMember(wasmGlobalPrototype, PropertyIds::constructor, library->undefinedValue /*no c-tor sry*/);
+
+        if (scriptContext->GetConfig()->IsES6ToStringTagEnabled())
+        {
+            library->AddMember(wasmGlobalPrototype, PropertyIds::_symbolToStringTag, library->CreateStringFromCppLiteral(_u("WasmGlobal")), PropertyConfigurable);
+        }
+
+        wasmGlobalPrototype->SetHasNoEnumerableProperties(true);
     }
 
     void  JavascriptLibrary::InitializeArrayBufferConstructor(DynamicObject* arrayBufferConstructor, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode)

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -1271,9 +1271,7 @@ namespace Js
         static void __cdecl JavascriptLibrary::InitializeAsyncFunction(DynamicObject *function, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
         static void __cdecl InitializeAsyncFunctionConstructor(DynamicObject* asyncFunctionConstructor, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
         static void __cdecl InitializeAsyncFunctionPrototype(DynamicObject* asyncFunctionPrototype, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
-
-        static void __cdecl InitializeWasmGlobalConstructor(DynamicObject* wasmGlobalConstructor, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
-        static void __cdecl InitializeWasmGlobalPrototype(DynamicObject* arrayBufferPrototype, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
+        static void __cdecl InitializeWasmGlobalPrototype(DynamicObject* wasmGlobalPrototype, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
         
 
         RuntimeFunction* CreateBuiltinConstructor(FunctionInfo * functionInfo, DynamicTypeHandler * typeHandler, DynamicObject* prototype = nullptr);

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -223,6 +223,7 @@ namespace Js
         DynamicType * promiseType;
         DynamicType * javascriptEnumeratorIteratorType;
         DynamicType * listIteratorType;
+        DynamicType * wasmGlobalType;
 
         JavascriptFunction* builtinFunctions[BuiltinFunction::Count];
 
@@ -764,6 +765,8 @@ namespace Js
         DynamicType * GetRegexType() const { return regexType; }
         DynamicType * GetRegexResultType() const { return regexResultType; }
         DynamicType * GetArrayBufferType() const { return arrayBufferType; }
+        DynamicType * GetWasmGlobalType() const { return wasmGlobalType; }
+
         StaticType  * GetStringTypeStatic() const { AssertMsg(stringTypeStatic, "Where's stringTypeStatic?"); return stringTypeStatic; }
         DynamicType * GetStringTypeDynamic() const { return stringTypeDynamic; }
         StaticType  * GetVariantDateType() const { return variantDateType; }
@@ -1268,6 +1271,10 @@ namespace Js
         static void __cdecl JavascriptLibrary::InitializeAsyncFunction(DynamicObject *function, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
         static void __cdecl InitializeAsyncFunctionConstructor(DynamicObject* asyncFunctionConstructor, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
         static void __cdecl InitializeAsyncFunctionPrototype(DynamicObject* asyncFunctionPrototype, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
+
+        static void __cdecl InitializeWasmGlobalConstructor(DynamicObject* wasmGlobalConstructor, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
+        static void __cdecl InitializeWasmGlobalPrototype(DynamicObject* arrayBufferPrototype, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
+        
 
         RuntimeFunction* CreateBuiltinConstructor(FunctionInfo * functionInfo, DynamicTypeHandler * typeHandler, DynamicObject* prototype = nullptr);
         RuntimeFunction* DefaultCreateFunction(FunctionInfo * functionInfo, int length, DynamicObject * prototype, DynamicType * functionType, PropertyId nameId);

--- a/lib/Runtime/Library/JavascriptLibraryBase.h
+++ b/lib/Runtime/Library/JavascriptLibraryBase.h
@@ -170,7 +170,6 @@ namespace Js
         RuntimeFunction* promiseConstructor;
         RuntimeFunction* generatorFunctionConstructor;
         RuntimeFunction* asyncFunctionConstructor;
-        RuntimeFunction* wasmGlobalConstructor;
 
         JavascriptFunction* defaultAccessorFunction;
         JavascriptFunction* stackTraceAccessorFunction;

--- a/lib/Runtime/Library/JavascriptLibraryBase.h
+++ b/lib/Runtime/Library/JavascriptLibraryBase.h
@@ -170,6 +170,7 @@ namespace Js
         RuntimeFunction* promiseConstructor;
         RuntimeFunction* generatorFunctionConstructor;
         RuntimeFunction* asyncFunctionConstructor;
+        RuntimeFunction* wasmGlobalConstructor;
 
         JavascriptFunction* defaultAccessorFunction;
         JavascriptFunction* stackTraceAccessorFunction;
@@ -256,6 +257,9 @@ namespace Js
         DynamicObject* simdUint32x4Prototype;
         DynamicObject* simdFloat32x4Prototype;
         DynamicObject* simdFloat64x2Prototype;
+
+        //Wasm Prototypes
+        DynamicObject* wasmGlobalPrototype;
 
         JavascriptBoolean* booleanTrue;
         JavascriptBoolean* booleanFalse;

--- a/lib/Runtime/Library/WasmLibrary.h
+++ b/lib/Runtime/Library/WasmLibrary.h
@@ -33,9 +33,11 @@ namespace Js
         static void WasmLoadDataSegs(Wasm::WasmModule * wasmModule, Var* heap, ScriptContext* ctx);
         static void WasmLoadFunctions(Wasm::WasmModule * wasmModule, ScriptContext* ctx, Var* moduleMemoryPtr, Var* exportObj, Var* localModuleFunctions, bool* hasAnyLazyTraps);
         static Var WasmLoadExports(Wasm::WasmModule * wasmModule, ScriptContext* ctx, Var* localModuleFunctions);
-        static void WasmBuildObject(Wasm::WasmModule * wasmModule, ScriptContext* ctx, Var exportsNamespace, Var* heap, Var* exportObj, bool* hasAnyLazyTraps, Var* localModuleFunctions);
+        static void WasmBuildObject(Wasm::WasmModule * wasmModule, ScriptContext* ctx, Var exportsNamespace, Var* heap, Var* exportObj, bool* hasAnyLazyTraps, Var* localModuleFunctions, Var globals);
         static void WasmLoadImports(Wasm::WasmModule * wasmModule, ScriptContext* ctx, Var* importFunctions, Var ffi);
         static void WasmLoadIndirectFunctionTables(Wasm::WasmModule * wasmModule, ScriptContext* ctx, Var** indirectFunctionTables, Var* localModuleFunctions);
+        static void WasmLoadGlobals(Wasm::WasmModule * wasmModule, ScriptContext* ctx, Var globals, Var ffi);
+        
 
         static Var LoadWasmScript(
             ScriptContext* scriptContext,

--- a/lib/Runtime/Types/EdgeJavascriptTypeId.h
+++ b/lib/Runtime/Types/EdgeJavascriptTypeId.h
@@ -110,17 +110,18 @@ enum TypeId
     TypeIds_JavascriptEnumeratorIterator = 67,
     TypeIds_Generator = 68,
     TypeIds_Promise = 69,
+    TypeIds_WasmGlobal = 70,
 
-    TypeIds_LastBuiltinDynamicObject = TypeIds_Promise,
-    TypeIds_GlobalObject = 70,
-    TypeIds_ModuleRoot = 71,
+    TypeIds_LastBuiltinDynamicObject = TypeIds_WasmGlobal,
+    TypeIds_GlobalObject = 71,
+    TypeIds_ModuleRoot = 72,
     TypeIds_LastTrueJavascriptObjectType = TypeIds_ModuleRoot,
 
-    TypeIds_HostObject = 72,
-    TypeIds_ActivationObject = 73,
-    TypeIds_SpreadArgument = 74,
-    TypeIds_ModuleNamespace = 75,
-    TypeIds_ListIterator = 76,
+    TypeIds_HostObject = 73,
+    TypeIds_ActivationObject = 74,
+    TypeIds_SpreadArgument = 75,
+    TypeIds_ModuleNamespace = 76,
+    TypeIds_ListIterator = 77,
 
     TypeIds_Limit //add a new TypeId before TypeIds_Limit or before TypeIds_LastTrueJavascriptObjectType
 };

--- a/lib/WasmReader/Chakra.WasmReader.vcxproj
+++ b/lib/WasmReader/Chakra.WasmReader.vcxproj
@@ -44,8 +44,10 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)WasmBinaryReader.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)WasmSection.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)WasmSignature.cpp" />
+    <ClCompile Include="WasmGlobal.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="WasmGlobal.h" />
     <ClInclude Include="WasmModule.h" />
     <ClInclude Include="WasmBytecodeGenerator.h" />
     <ClInclude Include="WasmDataSegment.h" />

--- a/lib/WasmReader/Chakra.WasmReader.vcxproj.filters
+++ b/lib/WasmReader/Chakra.WasmReader.vcxproj.filters
@@ -13,6 +13,7 @@
     <ClInclude Include="WasmSections.h" />
     <ClInclude Include="WasmSection.h" />
     <ClInclude Include="WasmDataSegment.h" />
+    <ClInclude Include="WasmGlobal.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)WasmModule.cpp" />
@@ -23,5 +24,6 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)WasmSection.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)WasmSignature.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)WasmReaderPch.cpp" />
+    <ClCompile Include="WasmGlobal.cpp" />
   </ItemGroup>
 </Project>

--- a/lib/WasmReader/WasmBinaryOpCodes.h
+++ b/lib/WasmReader/WasmBinaryOpCodes.h
@@ -96,8 +96,8 @@ WASM_MISC_OPCODE(Call,         0x16, Limit, false)
 WASM_MISC_OPCODE(CallIndirect, 0x17, Limit, false)
 WASM_MISC_OPCODE(CallImport,   0x18, Limit, false)
 WASM_MISC_OPCODE(TeeLocal,     0x19, Limit, false)
-WASM_MISC_OPCODE(GetGlobal,    0xbb, Limit, true)
-WASM_MISC_OPCODE(SetGlobal,    0xbc, Limit, true)
+WASM_MISC_OPCODE(GetGlobal,    0xbb, Limit, false)
+WASM_MISC_OPCODE(SetGlobal,    0xbc, Limit, false)
 
 // Load memory expressions.
 WASM_MEMREAD_OPCODE(I32LoadMem8S,  0x20, I_I, false)

--- a/lib/WasmReader/WasmBinaryOpCodes.h
+++ b/lib/WasmReader/WasmBinaryOpCodes.h
@@ -96,6 +96,8 @@ WASM_MISC_OPCODE(Call,         0x16, Limit, false)
 WASM_MISC_OPCODE(CallIndirect, 0x17, Limit, false)
 WASM_MISC_OPCODE(CallImport,   0x18, Limit, false)
 WASM_MISC_OPCODE(TeeLocal,     0x19, Limit, false)
+WASM_MISC_OPCODE(GetGlobal,    0xbb, Limit, true)
+WASM_MISC_OPCODE(SetGlobal,    0xbc, Limit, true)
 
 // Load memory expressions.
 WASM_MEMREAD_OPCODE(I32LoadMem8S,  0x20, I_I, false)

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -61,6 +61,7 @@ namespace Wasm
         void ReadImportEntries();
         void ReadStartFunction();
         void ReadNamesSection();
+        void ReadGlobalsSection();
 
         // Primitive reader
         template <WasmTypes::WasmType type> void ConstNode();

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -76,6 +76,7 @@ namespace Wasm
         bool EndOfModule();
         DECLSPEC_NORETURN void ThrowDecodingError(const char16* msg, ...);
         Wasm::WasmTypes::WasmType ReadWasmType(uint32& length);
+        WasmExternalKinds::WasmExternalKind ReadExternalKind(uint32& length);
 
         ArenaAllocator* m_alloc;
         uint m_funcNumber;

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -590,7 +590,7 @@ WasmBytecodeGenerator::EmitGetGlobal()
     Js::RegSlot constIndexReg = m_i32RegSlots.AcquireTmpRegister();
     m_writer.AsmInt1Const1(Js::OpCodeAsmJs::Ld_IntConst, constIndexReg, globalIndex);
 
-    WasmTypes::WasmType ty = static_cast<WasmTypes::WasmType>(glob.getType());
+    WasmTypes::WasmType ty = static_cast<WasmTypes::WasmType>(glob.GetType());
 
     static const Js::OpCodeAsmJs globalOpcodes[] = { 
         Js::OpCodeAsmJs::GetGlobal_Int, 
@@ -606,7 +606,6 @@ WasmBytecodeGenerator::EmitGetGlobal()
     EmitInfo info(tmpReg, ty);
 
     m_writer.AsmReg2(globalOpcodes[ty-1], tmpReg, constIndexReg);
-    //ReleaseLocation(constIndexReg);
     return info;
 }
 
@@ -615,7 +614,7 @@ WasmBytecodeGenerator::EmitSetGlobal()
 {
     uint globalIndex = GetReader()->m_currentNode.var.num;
     WasmGlobal glob = m_module->GetGlobal(globalIndex);
-    WasmTypes::WasmType ty = static_cast<WasmTypes::WasmType>(glob.getType());
+    WasmTypes::WasmType ty = static_cast<WasmTypes::WasmType>(glob.GetType());
 
     EmitInfo info = PopEvalStack();
 

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -585,12 +585,12 @@ EmitInfo
 WasmBytecodeGenerator::EmitGetGlobal() 
 {
     uint globalIndex = GetReader()->m_currentNode.var.num;
-    WasmGlobal* glob = m_module->GetGlobal(globalIndex);
+    WasmGlobal glob = m_module->GetGlobal(globalIndex);
 
     Js::RegSlot constIndexReg = m_i32RegSlots.AcquireTmpRegister();
     m_writer.AsmInt1Const1(Js::OpCodeAsmJs::Ld_IntConst, constIndexReg, globalIndex);
 
-    WasmTypes::WasmType ty = static_cast<WasmTypes::WasmType>(glob->getType());
+    WasmTypes::WasmType ty = static_cast<WasmTypes::WasmType>(glob.getType());
 
     static const Js::OpCodeAsmJs globalOpcodes[] = { 
         Js::OpCodeAsmJs::GetGlobal_Int, 
@@ -614,8 +614,8 @@ EmitInfo
 WasmBytecodeGenerator::EmitSetGlobal() 
 {
     uint globalIndex = GetReader()->m_currentNode.var.num;
-    WasmGlobal* glob = m_module->GetGlobal(globalIndex);
-    WasmTypes::WasmType ty = static_cast<WasmTypes::WasmType>(glob->getType());
+    WasmGlobal glob = m_module->GetGlobal(globalIndex);
+    WasmTypes::WasmType ty = static_cast<WasmTypes::WasmType>(glob.getType());
 
     EmitInfo info = PopEvalStack();
 

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -106,6 +106,10 @@ WasmModuleGenerator::GenerateModule()
     afterSectionCallback[bSectIndirectFunctionTable] = [](WasmModuleGenerator* gen) {
         gen->m_module->SetIndirFuncTableOffset(gen->m_module->GetFuncOffset() + gen->m_module->GetFunctionCount());
     };
+    afterSectionCallback[bSectGlobal] = [](WasmModuleGenerator* gen) {
+        gen->m_module->SetGlobalOffset(gen->m_module->GetFuncOffset() + gen->m_module->GetFunctionCount());
+    };
+
     afterSectionCallback[bSectFunctionBodies] = [](WasmModuleGenerator* gen) {
         uint32 funcCount = gen->m_module->GetFunctionCount();
         for (uint32 i = 0; i < funcCount; ++i)
@@ -476,6 +480,12 @@ WasmBytecodeGenerator::EmitExpr(WasmOp op)
 
     switch (op)
     {
+    case wbGetGlobal:
+        info = EmitGetGlobal();
+        break;
+    case wbSetGlobal:
+        info = EmitSetGlobal();
+        break;
     case wbGetLocal:
         info = EmitGetLocal();
         break;
@@ -570,6 +580,71 @@ WasmBytecodeGenerator::EmitExpr(WasmOp op)
     PushEvalStack(info);
     return info;
 }
+
+EmitInfo
+WasmBytecodeGenerator::EmitGetGlobal() 
+{
+    uint globalIndex = GetReader()->m_currentNode.var.num;
+    WasmGlobal* glob = m_module->GetGlobal(globalIndex);
+
+    Js::RegSlot constIndexReg = m_i32RegSlots.AcquireTmpRegister();
+    m_writer.AsmInt1Const1(Js::OpCodeAsmJs::Ld_IntConst, constIndexReg, globalIndex);
+
+    WasmTypes::WasmType ty = static_cast<WasmTypes::WasmType>(glob->getType());
+
+    static const Js::OpCodeAsmJs globalOpcodes[] = { 
+        Js::OpCodeAsmJs::GetGlobal_Int, 
+        Js::OpCodeAsmJs::LdUndef, //no i64 yet
+        Js::OpCodeAsmJs::GetGlobal_Flt, 
+        Js::OpCodeAsmJs::GetGlobal_Db 
+    };
+
+    Assert(globalOpcodes[ty - 1] != Js::OpCodeAsmJs::LdUndef);
+
+    WasmRegisterSpace * regSpace = GetRegisterSpace(ty);
+    Js::RegSlot tmpReg = regSpace->AcquireTmpRegister();
+    EmitInfo info(tmpReg, ty);
+
+    m_writer.AsmReg2(globalOpcodes[ty-1], tmpReg, constIndexReg);
+    //ReleaseLocation(constIndexReg);
+    return info;
+}
+
+EmitInfo
+WasmBytecodeGenerator::EmitSetGlobal() 
+{
+    uint globalIndex = GetReader()->m_currentNode.var.num;
+    WasmGlobal* glob = m_module->GetGlobal(globalIndex);
+    WasmTypes::WasmType ty = static_cast<WasmTypes::WasmType>(glob->getType());
+
+    EmitInfo info = PopEvalStack();
+
+
+    if (info.type != ty)
+    {
+        throw WasmCompilationException(_u("TypeError in setglobal for %u"), globalIndex);
+    }
+
+
+    static const Js::OpCodeAsmJs globalOpcodes[] = {
+        Js::OpCodeAsmJs::SetGlobal_Int,
+        Js::OpCodeAsmJs::LdUndef, //no i64 yet
+        Js::OpCodeAsmJs::SetGlobal_Flt,
+        Js::OpCodeAsmJs::SetGlobal_Db
+    };
+
+    Js::RegSlot constIndexReg = m_i32RegSlots.AcquireTmpRegister();
+    m_writer.AsmInt1Const1(Js::OpCodeAsmJs::Ld_IntConst, constIndexReg, globalIndex);
+    m_writer.AsmReg2(globalOpcodes[ty - 1], constIndexReg, info.location);
+
+
+    m_i32RegSlots.ReleaseTmpRegister(constIndexReg);
+    ReleaseLocation(&info);
+
+    return EmitInfo();
+}
+
+
 
 EmitInfo
 WasmBytecodeGenerator::EmitGetLocal()

--- a/lib/WasmReader/WasmByteCodeGenerator.h
+++ b/lib/WasmReader/WasmByteCodeGenerator.h
@@ -123,7 +123,9 @@ namespace Wasm
         EmitInfo EmitBrTable();
         EmitInfo EmitDrop();
         EmitInfo EmitGetLocal();
+        EmitInfo EmitGetGlobal();
         EmitInfo EmitSetLocal(bool tee);
+        EmitInfo EmitSetGlobal();
         EmitInfo EmitReturnExpr();
         EmitInfo EmitSelect();
 #if DBG_DUMP

--- a/lib/WasmReader/WasmGlobal.cpp
+++ b/lib/WasmReader/WasmGlobal.cpp
@@ -1,0 +1,39 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "WasmReaderPch.h"
+
+#ifdef ENABLE_WASM
+
+namespace Wasm
+{
+
+WasmGlobal::WasmGlobal(ArenaAllocator * alloc, uint32 _type, bool _mutability) : 
+    type(_type), 
+    mutability(_mutability), 
+    init(nullptr)
+{
+}
+
+uint32 
+WasmGlobal::getType() const
+{
+    return type;
+}
+
+bool
+WasmGlobal::getMutability() const
+{
+    return mutability;
+}
+
+WasmNode*
+WasmGlobal::getInit() const
+{
+    return init;
+}
+
+} // namespace Wasm
+#endif // ENABLE_WASM

--- a/lib/WasmReader/WasmGlobal.cpp
+++ b/lib/WasmReader/WasmGlobal.cpp
@@ -11,22 +11,22 @@ namespace Wasm
 {
 
 WasmGlobal::WasmGlobal(uint32 _type, bool _mutability) : 
-    type(_type), 
-    mutability(_mutability), 
-    ptype(Invalid)
+    m_type(_type), 
+    m_mutability(_mutability), 
+    m_rType(Invalid)
 {
 }
 
 uint32 
-WasmGlobal::getType() const
+WasmGlobal::GetType() const
 {
-    return type;
+    return m_type;
 }
 
 bool
-WasmGlobal::getMutability() const
+WasmGlobal::GetMutability() const
 {
-    return mutability;
+    return m_mutability;
 }
 } // namespace Wasm
 #endif // ENABLE_WASM

--- a/lib/WasmReader/WasmGlobal.cpp
+++ b/lib/WasmReader/WasmGlobal.cpp
@@ -10,12 +10,10 @@
 namespace Wasm
 {
 
-WasmGlobal::WasmGlobal(ArenaAllocator * alloc, uint32 _type, bool _mutability) : 
+WasmGlobal::WasmGlobal(uint32 _type, bool _mutability) : 
     type(_type), 
     mutability(_mutability), 
-    import(false),
-    ref(false),
-    init(nullptr)
+    ptype(Invalid)
 {
 }
 
@@ -30,12 +28,5 @@ WasmGlobal::getMutability() const
 {
     return mutability;
 }
-
-WasmNode*
-WasmGlobal::getInit() const
-{
-    return init;
-}
-
 } // namespace Wasm
 #endif // ENABLE_WASM

--- a/lib/WasmReader/WasmGlobal.cpp
+++ b/lib/WasmReader/WasmGlobal.cpp
@@ -13,6 +13,8 @@ namespace Wasm
 WasmGlobal::WasmGlobal(ArenaAllocator * alloc, uint32 _type, bool _mutability) : 
     type(_type), 
     mutability(_mutability), 
+    import(false),
+    ref(false),
     init(nullptr)
 {
 }

--- a/lib/WasmReader/WasmGlobal.h
+++ b/lib/WasmReader/WasmGlobal.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+
+
 namespace Wasm
 {
 
@@ -15,6 +17,17 @@ namespace Wasm
         uint32 getType() const;
         bool getMutability() const;
         WasmNode* getInit() const;
+        bool import; //TODO maybe merge these two via enum?
+        bool ref;
+
+        union
+        {
+            WasmConstLitNode cnst;
+            //Js::WasmGlobal::WasmConst cnst;
+            WasmVarNode var;
+            WasmNode* init;
+            GlobalImport* importVar;
+        };
 
     private:
         //ArenaAllocator * m_alloc;
@@ -22,14 +35,6 @@ namespace Wasm
         uint32 type;
         bool mutability;
 
-        union
-        {
-            WasmNode * init;
-            int32 i32;
-            float f32;
-            int64 i64;
-            double d;
-        };
         
     };
 } // namespace Wasm

--- a/lib/WasmReader/WasmGlobal.h
+++ b/lib/WasmReader/WasmGlobal.h
@@ -16,12 +16,13 @@ namespace Wasm
 
     public:
 
-        enum PointerType { Invalid, Const, LocalReference, ImportedReference };
+        enum ReferenceType { Invalid, Const, LocalReference, ImportedReference };
 
         WasmGlobal(uint32 _type, bool mutability);
-        uint32 getType() const;
-        bool getMutability() const;
-        PointerType ptype;
+        uint32 GetType() const;
+        bool GetMutability() const;
+        ReferenceType GetReferenceType() { return m_rType; };
+        void SetReferenceType(ReferenceType rt) { m_rType = rt; };
 
         union
         {
@@ -32,8 +33,9 @@ namespace Wasm
 
     private:
 
-        uint32 type;
-        bool mutability;
+        ReferenceType m_rType;
+        uint32 m_type;
+        bool m_mutability;
 
         
     };

--- a/lib/WasmReader/WasmGlobal.h
+++ b/lib/WasmReader/WasmGlobal.h
@@ -1,0 +1,35 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+namespace Wasm
+{
+
+    class WasmGlobal
+    {
+    public:
+        WasmGlobal(ArenaAllocator * alloc, uint32 _type, bool mutability);
+        uint32 getType() const;
+        bool getMutability() const;
+        WasmNode* getInit() const;
+
+    private:
+        //ArenaAllocator * m_alloc;
+
+        uint32 type;
+        bool mutability;
+
+        union
+        {
+            WasmNode * init;
+            int32 i32;
+            float f32;
+            int64 i64;
+            double d;
+        };
+        
+    };
+} // namespace Wasm

--- a/lib/WasmReader/WasmGlobal.h
+++ b/lib/WasmReader/WasmGlobal.h
@@ -12,25 +12,25 @@ namespace Wasm
 
     class WasmGlobal
     {
+        
+
     public:
-        WasmGlobal(ArenaAllocator * alloc, uint32 _type, bool mutability);
+
+        enum PointerType { Invalid, Const, LocalReference, ImportedReference };
+
+        WasmGlobal(uint32 _type, bool mutability);
         uint32 getType() const;
         bool getMutability() const;
-        WasmNode* getInit() const;
-        bool import; //TODO maybe merge these two via enum?
-        bool ref;
+        PointerType ptype;
 
         union
         {
             WasmConstLitNode cnst;
-            //Js::WasmGlobal::WasmConst cnst;
             WasmVarNode var;
-            WasmNode* init;
             GlobalImport* importVar;
         };
 
     private:
-        //ArenaAllocator * m_alloc;
 
         uint32 type;
         bool mutability;

--- a/lib/WasmReader/WasmModule.cpp
+++ b/lib/WasmReader/WasmModule.cpp
@@ -230,6 +230,27 @@ WasmModule::GetDataSeg(uint32 index) const
     return m_datasegs[index];
 }
 
+bool
+WasmModule::AddGlobal(WasmGlobal* g, uint32 index)
+{
+    if (index >= m_globalCount)
+    {
+        return false;
+    }
+    m_globals[index] = g;
+    return true;
+}
+
+WasmGlobal*
+WasmModule::GetGlobal(uint32 index) const
+{
+    if (index >= m_globalCount)
+    {
+        return nullptr;
+    }
+    return m_globals[index];
+}
+
 void
 WasmModule::SetStartFunction(uint32 i)
 {

--- a/lib/WasmReader/WasmModule.cpp
+++ b/lib/WasmReader/WasmModule.cpp
@@ -269,11 +269,23 @@ WasmModule::AddGlobal(WasmGlobal* g, uint32 index)
     return true;
 }
 
-WasmGlobal*
+WasmGlobal
 WasmModule::GetGlobal(uint32 index) const
 {
-    Assert(index < m_globalCount);
-    return m_globals[index];   
+    if (index >= GetGlobalCount()) 
+    {
+        throw WasmCompilationException(_u("Global index %d is out of bounds"), index);
+    }
+
+    if (index < GetImportGlobalCount())
+    {
+         WasmGlobal global(m_globalImports[index].type, m_globalImports[index].mut);
+         global.importVar = &m_globalImports[index];
+         global.ptype = WasmGlobal::ImportedReference;
+         return global;
+    }
+    
+    return *m_globals[index - GetImportGlobalCount()];
 }
 
 void

--- a/lib/WasmReader/WasmModule.cpp
+++ b/lib/WasmReader/WasmModule.cpp
@@ -198,7 +198,7 @@ WasmModule::SetGlobalImport(uint32 i, WasmImport ie, bool mut, WasmTypes::WasmTy
 Wasm::GlobalImport*
 WasmModule::GetGlobalImport(uint32 i) const
 {
-    if (i >= m_importCount)
+    if (i >= m_importGlobalCount)
     {
         return nullptr;
     }
@@ -281,7 +281,7 @@ WasmModule::GetGlobal(uint32 index) const
     {
          WasmGlobal global(m_globalImports[index].type, m_globalImports[index].mut);
          global.importVar = &m_globalImports[index];
-         global.ptype = WasmGlobal::ImportedReference;
+         global.SetReferenceType(WasmGlobal::ImportedReference);
          return global;
     }
     

--- a/lib/WasmReader/WasmModule.h
+++ b/lib/WasmReader/WasmModule.h
@@ -59,6 +59,10 @@ namespace Wasm
         WasmDataSegment* GetDataSeg(uint32 index) const;
         uint32 GetDataSegCount() const { return m_datasegCount; }
 
+        bool AddGlobal(WasmGlobal* g, uint32 index);
+        WasmGlobal* GetGlobal(uint32 index) const;
+        uint32 GetGlobalCount() const { return m_globalCount; }
+
         void SetStartFunction(uint32 i);
         uint32 GetStartFunction() const;
 
@@ -86,6 +90,7 @@ namespace Wasm
         WasmExport* m_exports;
         WasmImport* m_imports;
         WasmDataSegment** m_datasegs;
+        WasmGlobal** m_globals;
         WasmBinaryReader* m_reader;
 
         uint m_signaturesCount;
@@ -94,6 +99,7 @@ namespace Wasm
         uint m_exportCount;
         uint32 m_importCount;
         uint32 m_datasegCount;
+        uint32 m_globalCount;
 
         uint32 m_startFuncIndex;
 

--- a/lib/WasmReader/WasmModule.h
+++ b/lib/WasmReader/WasmModule.h
@@ -46,13 +46,16 @@ namespace Wasm
 
         void AllocateFunctionExports(uint32 entries);
         uint GetExportCount() const { return m_exportCount; }
-        void SetFunctionExport(uint32 iExport, uint32 funcIndex, char16* exportName, uint32 nameLength);
+        void SetFunctionExport(uint32 iExport, uint32 funcIndex, char16* exportName, uint32 nameLength, WasmExternalKinds::WasmExternalKind ekind);
         WasmExport* GetFunctionExport(uint32 iExport) const;
 
-        void AllocateFunctionImports(uint32 entries);
+        void AllocateImports(uint32 entries);
         uint32 GetImportCount() const { return m_importCount; }
-        void SetFunctionImport(uint32 i, uint32 sigId, char16* modName, uint32 modNameLen, char16* fnName, uint32 fnNameLen);
-        WasmImport* GetFunctionImport(uint32 i) const;
+        void SetFunctionImport(uint32 i, WasmImport ie, uint32 sigId);
+        void SetGlobalImport(uint32 i, WasmImport ie, bool mut, WasmTypes::WasmType ty);
+        //void SetFunctionImport(uint32 i, uint32 sigId, char16* modName, uint32 modNameLen, char16* fnName, uint32 fnNameLen);
+        GlobalImport* GetGlobalImport(uint32 i) const;
+        FunctionImport* GetFunctionImport(uint32 i) const;
 
         void AllocateDataSegs(uint32 count);
         bool AddDataSeg(WasmDataSegment* seg, uint32 index);
@@ -62,6 +65,11 @@ namespace Wasm
         bool AddGlobal(WasmGlobal* g, uint32 index);
         WasmGlobal* GetGlobal(uint32 index) const;
         uint32 GetGlobalCount() const { return m_globalCount; }
+        void SetGlobalCount(uint32 count);
+        void IncImportGlobalCount() { m_importedGlobalCount++;  }
+        void ResetImportGlobalCount() { m_importedGlobalCount = 0; }
+        uint32 GetImportGlobalCount() { return m_importedGlobalCount; }
+        
 
         void SetStartFunction(uint32 i);
         uint32 GetStartFunction() const;
@@ -76,6 +84,8 @@ namespace Wasm
         void SetImportFuncOffset(uint val) { importFuncOffset = val; }
         uint GetIndirFuncTableOffset() const { return indirFuncTableOffset; }
         void SetIndirFuncTableOffset(uint val) { indirFuncTableOffset = val; }
+        uint GetGlobalOffset() const { return globalOffset;  }
+        void SetGlobalOffset(uint val) { globalOffset = val; }
 
         WasmBinaryReader* GetReader() const { return m_reader; }
 
@@ -88,7 +98,8 @@ namespace Wasm
         uint32* m_indirectfuncs;
         WasmFunctionInfo** m_functionsInfo;
         WasmExport* m_exports;
-        WasmImport* m_imports;
+        FunctionImport* m_imports;
+        GlobalImport* m_globalImports;
         WasmDataSegment** m_datasegs;
         WasmGlobal** m_globals;
         WasmBinaryReader* m_reader;
@@ -100,6 +111,7 @@ namespace Wasm
         uint32 m_importCount;
         uint32 m_datasegCount;
         uint32 m_globalCount;
+        uint32 m_importedGlobalCount;
 
         uint32 m_startFuncIndex;
 
@@ -110,5 +122,6 @@ namespace Wasm
         uint funcOffset;
         uint importFuncOffset;
         uint indirFuncTableOffset;
+        uint globalOffset;
     };
 } // namespace Wasm

--- a/lib/WasmReader/WasmModule.h
+++ b/lib/WasmReader/WasmModule.h
@@ -53,9 +53,9 @@ namespace Wasm
         uint32 GetImportCount() const { return m_importCount; }
         void SetFunctionImport(uint32 i, WasmImport ie, uint32 sigId);
         void SetGlobalImport(uint32 i, WasmImport ie, bool mut, WasmTypes::WasmType ty);
-        //void SetFunctionImport(uint32 i, uint32 sigId, char16* modName, uint32 modNameLen, char16* fnName, uint32 fnNameLen);
         GlobalImport* GetGlobalImport(uint32 i) const;
         FunctionImport* GetFunctionImport(uint32 i) const;
+        void SetImportFunctionCount(uint count) { m_importCount = count;  }
 
         void AllocateDataSegs(uint32 count);
         bool AddDataSeg(WasmDataSegment* seg, uint32 index);
@@ -64,12 +64,11 @@ namespace Wasm
 
         bool AddGlobal(WasmGlobal* g, uint32 index);
         WasmGlobal GetGlobal(uint32 index) const;
-        uint32 GetGlobalCount() const { return m_globalCount + m_importedGlobalCount; }
+        uint32 GetGlobalCount() const { return m_globalCount + m_importGlobalCount; }
         uint32 GetLocalGlobalCount() const { return m_globalCount;  }
         void SetGlobalCount(uint32 count);
-        void IncImportGlobalCount() { m_importedGlobalCount++;  }
-        void ResetImportGlobalCount() { m_importedGlobalCount = 0; }
-        uint32 GetImportGlobalCount() const { return m_importedGlobalCount; }
+        void SetImportGlobalCount(uint count) { m_importGlobalCount = count; }
+        uint32 GetImportGlobalCount() const { return m_importGlobalCount; }
         
 
         void SetStartFunction(uint32 i);
@@ -112,7 +111,7 @@ namespace Wasm
         uint32 m_importCount;
         uint32 m_datasegCount;
         uint32 m_globalCount;
-        uint32 m_importedGlobalCount;
+        uint32 m_importGlobalCount;
 
         uint32 m_startFuncIndex;
 

--- a/lib/WasmReader/WasmModule.h
+++ b/lib/WasmReader/WasmModule.h
@@ -63,12 +63,13 @@ namespace Wasm
         uint32 GetDataSegCount() const { return m_datasegCount; }
 
         bool AddGlobal(WasmGlobal* g, uint32 index);
-        WasmGlobal* GetGlobal(uint32 index) const;
-        uint32 GetGlobalCount() const { return m_globalCount; }
+        WasmGlobal GetGlobal(uint32 index) const;
+        uint32 GetGlobalCount() const { return m_globalCount + m_importedGlobalCount; }
+        uint32 GetLocalGlobalCount() const { return m_globalCount;  }
         void SetGlobalCount(uint32 count);
         void IncImportGlobalCount() { m_importedGlobalCount++;  }
         void ResetImportGlobalCount() { m_importedGlobalCount = 0; }
-        uint32 GetImportGlobalCount() { return m_importedGlobalCount; }
+        uint32 GetImportGlobalCount() const { return m_importedGlobalCount; }
         
 
         void SetStartFunction(uint32 i);

--- a/lib/WasmReader/WasmParseTree.h
+++ b/lib/WasmReader/WasmParseTree.h
@@ -23,6 +23,18 @@ namespace Wasm
         bool IsLocalType(WasmTypes::WasmType type);
     }
 
+    namespace WasmExternalKinds
+    {
+        enum WasmExternalKind
+        {
+            Function,
+            Table,
+            Memory,
+            Global,
+            Limit
+        };
+    };
+
     struct WasmOpCodeSignatures
     {
 #define WASM_SIGNATURE(id, nTypes, ...) static const WasmTypes::WasmType id[nTypes]; DebugOnly(static const int n##id = nTypes;)
@@ -36,6 +48,9 @@ namespace Wasm
         wbFuncEnd,
         wbLimit
     };
+
+
+
 
     struct WasmConstLitNode
     {
@@ -102,15 +117,53 @@ namespace Wasm
         uint32 funcIndex;
         uint32 nameLength;
         char16* name;
+        WasmExternalKinds::WasmExternalKind ekind;
     };
+
+    struct WasmAuxFuncImport 
+    {
+        
+    };
+
+    struct WasmAuxGlobalImport 
+    {
+
+    };
+
+    struct WasmAuxImport 
+    {
+        union 
+        {
+        WasmAuxFuncImport funcData;
+        WasmAuxGlobalImport globalData;
+        };
+    };
+
+
 
     struct WasmImport
     {
-        uint32 sigId;
+        //WasmExternalKinds::WasmExternalKind ekind;
+        //WasmAuxImport aux;
         uint32 modNameLen;
         char16* modName;
         uint32 fnNameLen;
         char16* fnName;
     };
+
+    struct FunctionImport : public WasmImport 
+    {
+        uint32 sigId;
+    };
+
+    struct GlobalImport : public WasmImport
+    {
+        bool mut;
+        WasmTypes::WasmType type;
+    };
+
+
+
+
 
 }

--- a/lib/WasmReader/WasmParseTree.h
+++ b/lib/WasmReader/WasmParseTree.h
@@ -120,31 +120,8 @@ namespace Wasm
         WasmExternalKinds::WasmExternalKind ekind;
     };
 
-    struct WasmAuxFuncImport 
-    {
-        
-    };
-
-    struct WasmAuxGlobalImport 
-    {
-
-    };
-
-    struct WasmAuxImport 
-    {
-        union 
-        {
-        WasmAuxFuncImport funcData;
-        WasmAuxGlobalImport globalData;
-        };
-    };
-
-
-
     struct WasmImport
     {
-        //WasmExternalKinds::WasmExternalKind ekind;
-        //WasmAuxImport aux;
         uint32 modNameLen;
         char16* modName;
         uint32 fnNameLen;

--- a/lib/WasmReader/WasmReader.h
+++ b/lib/WasmReader/WasmReader.h
@@ -61,6 +61,7 @@ namespace Wasm
 #include "WasmSignature.h"
 #include "WasmDataSegment.h"
 #include "WasmFunctionInfo.h"
+#include "WasmGlobal.h"
 #include "WasmModule.h"
 
 #include "WasmSection.h"

--- a/lib/WasmReader/WasmSections.h
+++ b/lib/WasmReader/WasmSections.h
@@ -9,11 +9,11 @@ WASM_SECTION(ImportTable          , "import"             , fSectNone  , Invalid 
 WASM_SECTION(FunctionSignatures   , "function"           , fSectNone  , Signatures        )
 WASM_SECTION(IndirectFunctionTable, "table"              , fSectNone  , FunctionSignatures)
 WASM_SECTION(Memory               , "memory"             , fSectNone  , Invalid           )
+WASM_SECTION(Global               , "global"             , fSectNone  , Invalid           )
 WASM_SECTION(ExportTable          , "export"             , fSectNone  , FunctionSignatures)
 WASM_SECTION(StartFunction        , "start"              , fSectNone  , FunctionSignatures)
 WASM_SECTION(FunctionBodies       , "code"               , fSectNone  , FunctionSignatures)
 WASM_SECTION(DataSegments         , "data"               , fSectNone  , Memory            )
 WASM_SECTION(Names                , "name"               , fSectNone  , Signatures        )
 WASM_SECTION(User                 , "user"               , fSectIgnore, Invalid           )
-
 #undef WASM_SECTION


### PR DESCRIPTION
Questions:
1. **(MINOR)** What's the best way to keep track of an offset into `globals` array? As of now, I'm reusing `AsmJsFunctionMemory::ArraySizeRegister`. We could probably create a register specifically for `globals` 
   - Is it okay to add another item to `FrameDisplay` which is later used to initialize the size/offset register?
2. **(MINOR)** `OP_SetGlobalInt/OP_GetGlobalInt`  I will try to templatize these to re-use as much code as possible.
3. I opted in to define a javascript object representing a wasm global variable. I tried to keep the number of properties to a minimum.
   - Am I missing any properties I should have added?
   - I'm setting a c-tor field of a prototype object to `undef` since we probably don't want to provide users with a way to create their wasm globals in javascript just yet. 
4.  **(MINOR)** I temporarily put this new class in `ArrayBuffer.h` since I didn't think of a better place to place it. 
   - Should I create a new file say `WasmStructures.h` in `lib/Runtime/Library`
5. **(MINOR)** I embedded `globalsArray` into `moduleEnvironment` since the number of globals is fixed and I didn't immediately see a benefit of allocating another array. 
6. **(MINOR)** I'm using `Wasm::WasmExternalKinds` which in Mike's version is called `ImportKinds`. Lots of merge fun for me :-) 
7. globals initialization is postponed until `globalsArray` is constructed and filled either with **reference** or **const** globals. This is to mostly simplify initialization logic. **Imported** globals and **Locally referenced** globals are treated in the exact same way. Also this way, we can support forward reference (e.g. `global_1` references `global_5`). 
   - One thing that is not entirely clear to me is whether cycles in globals are possible or not. I didn't see anything in a spec specifically discussing this meaning we should probably throw an error if `global_1` is initialized with `global_2` and `global_2` is initialized with `global_1`
8. `ReadGlobalsSection` creates a globals array a  bytecodegenerator can reference into. Seemed like a reasonable division labour to me.
9. `ImportEntries` is a mess :-( I separated `globals` and imported functions into two different lists since they are supposed to live in separate "logical" namespaces to allow us to index into both namespaces. Unfortunately, this means we should keep track of exactly how many functions and globals were imported (since it's not equal to the number of entries anymore). 
   - Maybe we could use lists to simplify the management of imports? 
